### PR TITLE
Remove clientDependencies option

### DIFF
--- a/src/spanner-assert.ts
+++ b/src/spanner-assert.ts
@@ -13,9 +13,8 @@ export function createSpannerAssert(
   options: SpannerAssertOptions
 ): SpannerAssertInstance {
   const resolvedConfig = resolveConnectionConfig(options.connection);
-  const dependencies = options.clientDependencies ?? {};
 
-  const openHandle = () => openDatabase(resolvedConfig, dependencies);
+  const openHandle = () => openDatabase(resolvedConfig);
 
   const assertWithExpectations = async (
     expectations: ExpectationsFile

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import type { SpannerClientDependencies } from "./spanner-client.ts";
-
 export type ColumnValue = string | number | boolean | null;
 
 export type TableColumnExpectations = Record<string, ColumnValue>;
@@ -24,7 +22,6 @@ export type ResolvedSpannerConnectionConfig = SpannerConnectionConfig;
 
 export type SpannerAssertOptions = {
   connection: SpannerConnectionConfig;
-  clientDependencies?: SpannerClientDependencies;
 };
 
 export type SpannerAssertInstance = {

--- a/tests/e2e/run.ts
+++ b/tests/e2e/run.ts
@@ -103,9 +103,6 @@ async function main(): Promise<void> {
       databaseId,
       emulatorHost,
     },
-    clientDependencies: {
-      database,
-    },
   });
 
   try {


### PR DESCRIPTION
## Summary
- Remove `clientDependencies` option from `SpannerAssertOptions`
- Simplify database connection management to use DSN-only approach
- Remove dependency injection pattern for Spanner client instances

## Changes
- **src/types.ts**: Remove `clientDependencies` property from `SpannerAssertOptions`
- **src/spanner-client.ts**: Remove `SpannerClientDependencies` type and dependency injection logic
- **src/spanner-assert.ts**: Remove dependency handling code
- **tests/e2e/run.ts**: Remove `clientDependencies` usage from test setup

## Impact
- Cleaner API: users only need to provide connection configuration
- Simpler implementation: no need to manage external database instances
- Each `SpannerAssert` instance manages its own database connection lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)