### PR TITLE
test: Add Playwright test integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Run emulator e2e tests
         run: task test:emulator
+      
+      - name: Run playwright tests
+        run: task test:playwright

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,3 +89,15 @@ tasks:
         trap 'task emulator:down >/dev/null 2>&1 || true' EXIT
         task emulator:setup
         pnpm run test:e2e
+
+  test:playwright:
+    desc: Run Playwright tests against the Spanner emulator
+    deps:
+      - build
+    cmds:
+      - |
+        set -euo pipefail
+        task emulator:up
+        trap 'task emulator:down >/dev/null 2>&1 || true' EXIT
+        task emulator:setup
+        pnpm exec playwright test

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
+    "@playwright/test": "^1.56.1",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.7.4",
     "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@eslint/js':
         specifier: ^9.13.0
         version: 9.37.0
+      '@playwright/test':
+        specifier: ^1.56.1
+        version: 1.56.1
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -672,6 +675,11 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.56.1':
+    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1622,6 +1630,11 @@ packages:
     resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2202,6 +2215,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.56.1:
+    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3174,6 +3197,10 @@ snapshots:
 
   '@oxc-transform/binding-win32-x64-msvc@0.67.0':
     optional: true
+
+  '@playwright/test@1.56.1':
+    dependencies:
+      playwright: 1.56.1
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -4212,6 +4239,9 @@ snapshots:
       mime-types: 2.1.35
       safe-buffer: 5.2.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4809,6 +4839,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.56.1: {}
+
+  playwright@1.56.1:
+    dependencies:
+      playwright-core: 1.56.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/e2e/run.ts
+++ b/tests/e2e/run.ts
@@ -3,83 +3,9 @@ import path from "node:path";
 import { Spanner } from "@google-cloud/spanner";
 
 import { createSpannerAssert } from "../../src/index.ts";
+import { seedSamples } from "../seed.ts";
 
 const fixturesDir = "tests/e2e/fixtures";
-
-async function seedSamples(
-  database: import("@google-cloud/spanner").Database
-): Promise<void> {
-  const createdAt = new Date("2024-01-01T00:00:00Z").toISOString();
-
-  await database.runTransactionAsync(async (transaction) => {
-    await transaction.batchUpdate([
-      {
-        sql: "DELETE FROM Users WHERE TRUE",
-      },
-      {
-        sql: "DELETE FROM Products WHERE TRUE",
-      },
-      {
-        sql: "DELETE FROM Books WHERE TRUE",
-      },
-      {
-        sql: `INSERT INTO Users (UserID, Name, Email, Status, CreatedAt)
-               VALUES (@userId, @name, @email, @status, TIMESTAMP(@createdAt))`,
-        params: {
-          userId: "user-001",
-          name: "Alice Example",
-          email: "alice@example.com",
-          status: 1,
-          createdAt,
-        },
-        types: {
-          userId: { type: "string" },
-          name: { type: "string" },
-          email: { type: "string" },
-          status: { type: "int64" },
-          createdAt: { type: "string" },
-        },
-      },
-      {
-        sql: `INSERT INTO Products (ProductID, Name, Price, IsActive, CategoryID, CreatedAt)
-               VALUES (@productId, @name, @price, @isActive, @categoryId, TIMESTAMP(@createdAt))`,
-        params: {
-          productId: "product-001",
-          name: "Example Product",
-          price: 1999,
-          isActive: true,
-          categoryId: null,
-          createdAt,
-        },
-        types: {
-          productId: { type: "string" },
-          name: { type: "string" },
-          price: { type: "int64" },
-          isActive: { type: "bool" },
-          categoryId: { type: "string" },
-          createdAt: { type: "string" },
-        },
-      },
-      {
-        sql: `INSERT INTO Books (BookID, Title, Author, PublishedYear)
-               VALUES (@bookId, @title, @author, @publishedYear)`,
-        params: {
-          bookId: "book-001",
-          title: "Example Book",
-          author: "Jane Doe",
-          publishedYear: 2024,
-        },
-        types: {
-          bookId: { type: "string" },
-          title: { type: "string" },
-          author: { type: "string" },
-          publishedYear: { type: "int64" },
-        },
-      },
-    ]);
-    await transaction.commit();
-  });
-}
 
 async function main(): Promise<void> {
   const projectId = process.env.SPANNER_PROJECT ?? "e2e-project";

--- a/tests/playwright/assert.spec.ts
+++ b/tests/playwright/assert.spec.ts
@@ -1,0 +1,28 @@
+import { test } from "@playwright/test";
+
+import { createSpannerAssert } from "../../src/spanner-assert.ts";
+import { SpannerAssertInstance } from "../../src/types.ts";
+import { seed } from "../seed.ts";
+
+// Create spanner-assert instance
+const spannerAssert: SpannerAssertInstance = createSpannerAssert({
+  connection: {
+    projectId: "e2e-project",
+    instanceId: "e2e-instance",
+    databaseId: "e2e-database",
+    emulatorHost: "127.0.0.1:9010",
+  },
+});
+
+// use in playwright tests
+test.describe("spanner-assert with Playwright", () => {
+  test.beforeAll(async () => {
+    await seed();
+  });
+
+  test("seeds are present in the emulator", async () => {
+    await spannerAssert.assert(
+      "./tests/e2e/fixtures/expectations/samples.yaml"
+    );
+  });
+});

--- a/tests/seed.ts
+++ b/tests/seed.ts
@@ -1,0 +1,87 @@
+import { Spanner } from "@google-cloud/spanner";
+
+export async function seed() {
+  const spanner = new Spanner({
+    projectId: "e2e-project",
+    servicePath: "127.0.0.1",
+    port: 9010,
+  });
+  const instance = spanner.instance("e2e-instance");
+  const database = instance.database("e2e-database");
+  await seedSamples(database);
+}
+
+export async function seedSamples(
+  database: import("@google-cloud/spanner").Database
+): Promise<void> {
+  const createdAt = new Date("2024-01-01T00:00:00Z").toISOString();
+
+  await database.runTransactionAsync(async (transaction) => {
+    await transaction.batchUpdate([
+      {
+        sql: "DELETE FROM Users WHERE TRUE",
+      },
+      {
+        sql: "DELETE FROM Products WHERE TRUE",
+      },
+      {
+        sql: "DELETE FROM Books WHERE TRUE",
+      },
+      {
+        sql: `INSERT INTO Users (UserID, Name, Email, Status, CreatedAt)
+               VALUES (@userId, @name, @email, @status, TIMESTAMP(@createdAt))`,
+        params: {
+          userId: "user-001",
+          name: "Alice Example",
+          email: "alice@example.com",
+          status: 1,
+          createdAt,
+        },
+        types: {
+          userId: { type: "string" },
+          name: { type: "string" },
+          email: { type: "string" },
+          status: { type: "int64" },
+          createdAt: { type: "string" },
+        },
+      },
+      {
+        sql: `INSERT INTO Products (ProductID, Name, Price, IsActive, CategoryID, CreatedAt)
+               VALUES (@productId, @name, @price, @isActive, @categoryId, TIMESTAMP(@createdAt))`,
+        params: {
+          productId: "product-001",
+          name: "Example Product",
+          price: 1999,
+          isActive: true,
+          categoryId: null,
+          createdAt,
+        },
+        types: {
+          productId: { type: "string" },
+          name: { type: "string" },
+          price: { type: "int64" },
+          isActive: { type: "bool" },
+          categoryId: { type: "string" },
+          createdAt: { type: "string" },
+        },
+      },
+      {
+        sql: `INSERT INTO Books (BookID, Title, Author, PublishedYear)
+               VALUES (@bookId, @title, @author, @publishedYear)`,
+        params: {
+          bookId: "book-001",
+          title: "Example Book",
+          author: "Jane Doe",
+          publishedYear: 2024,
+        },
+        types: {
+          bookId: { type: "string" },
+          title: { type: "string" },
+          author: { type: "string" },
+          publishedYear: { type: "int64" },
+        },
+      },
+    ]);
+    await transaction.commit();
+  });
+}


### PR DESCRIPTION
## Summary
- Add Playwright testing framework to the project
- Extract seed data utilities to shared module
- Add Playwright test configuration and CI integration

## Changes
- **package.json**: Add @playwright/test dependency
- **Taskfile.yml**: Add test:playwright task for running Playwright tests
- **.github/workflows/ci.yml**: Add Playwright test step to CI workflow
- **tests/seed.ts**: Extract seed data utilities from e2e tests
- **tests/e2e/run.ts**: Refactor to use shared seed utilities
- **tests/playwright/assert.spec.ts**: Add initial Playwright test

## Test Plan
- Playwright tests run against Spanner emulator
- CI workflow validates Playwright integration
- Existing e2e tests continue to work with refactored seed utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)