### PR TITLE
Add zizmor security analysis workflow

### DIFF
--- a/.github/workflows/gha-check.yaml
+++ b/.github/workflows/gha-check.yaml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for security analysis using zizmor
- Workflow runs on pushes to main and all pull requests
- Uses pinned commit hashes for security best practices

## Changes
- **`.github/workflows/gha-check.yaml`**: New workflow that runs zizmor security analysis on GitHub Actions workflows

## Benefits
- Automated security analysis of GitHub Actions workflows
- Helps identify potential security issues in CI/CD pipelines
- Uses SARIF format for integration with GitHub Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)