### PR TITLE
ci: prevent canceling workflow runs on main branch

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,6 +1,10 @@
 name: Lint GitHub Actions workflows
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary
- Add conditional `cancel-in-progress` to prevent canceling workflow runs on main branch
- Only cancel in-progress runs for pull request events
- Ensure all commits on main branch are validated

## Changes
- **`.github/workflows/actionlint.yaml`**: Update `cancel-in-progress` to conditional expression
- **`.github/workflows/ci.yaml`**: Update `cancel-in-progress` to conditional expression
- **`.github/workflows/zizmor.yaml`**: Update `cancel-in-progress` to conditional expression

## Behavior
- **Pull requests**: Old workflow runs are canceled when new commits are pushed
- **Main branch**: All commits are validated in parallel without cancellation
- **Other branches**: Same as pull requests (workflows continue independently)

## Validation
- All workflow files validated with actionlint
- No syntax errors detected