### PR TITLE
docs: remove remaining YAML references after migration to JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,7 +287,7 @@ CREATE TABLE user_sessions (...);
 
 ## CI/CD
 
-### GitHub Actions (.github/workflows/ci.yml)
+### GitHub Actions (.github/workflows/ci.yaml)
 1. Setup: pnpm/Node.js/Task
 2. Install `wrench` (Go tool for schema migration)
 3. Run: lint, typecheck, `task test:emulator`, `task test:playwright`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![CI](https://github.com/nu0ma/spanner-assert/actions/workflows/ci.yaml/badge.svg)](https://github.com/nu0ma/spanner-assert/actions/workflows/ci.yaml)
 [![License](https://img.shields.io/npm/l/spanner-assert)](https://github.com/nu0ma/spanner-assert/blob/main/LICENSE)
 
-Validate Google Cloud Spanner **emulator** data against expectations written in YAML. Lightweight Node.js testing library for E2E workflows, fast feedback loops.
 Validate Google Cloud Spanner **emulator** data against expectations written in JSON. Lightweight Node.js testing library for E2E workflows, fast feedback loops.
 
 > ⚠️ **This library only supports Cloud Spanner emulator** - designed for testing environments, not production databases.
@@ -284,13 +283,20 @@ The algorithm processes expected rows sequentially:
 
 ### Example: Subset Matching
 
-```yaml
-# Expected (only 2 columns specified)
-tables:
-  Users:
-    rows:
-      - Email: "alice@example.com"
-        Status: 1
+```json
+// Expected (only 2 columns specified)
+{
+  "tables": {
+    "Users": {
+      "rows": [
+        {
+          "Email": "alice@example.com",
+          "Status": 1
+        }
+      ]
+    }
+  }
+}
 ```
 
 This will match a database row even if it has additional columns:


### PR DESCRIPTION
## Summary

- Remove duplicate YAML description from README.md
- Convert YAML code example to JSON in README.md Row Matching section
- Update workflow file reference from `ci.yml` to `ci.yaml` in AGENTS.md

## Context

Follow-up to #62 which migrated from YAML to JSON expectations. This PR removes remaining YAML references in documentation that were missed in the initial migration.