### PR TITLE
ci: remove pnpm version specification from workflows

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10.18.3
 
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10.18.3
 
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0


### PR DESCRIPTION
## Summary
- Remove explicit pnpm version specification from GitHub Actions workflows
- Let pnpm/action-setup use the version defined in package.json's packageManager field

## Test plan
- Verify CI workflows pass with auto-detected pnpm version
- Confirm release workflow functions correctly