### PR TITLE
feat: add explicit close() method for connection management

### DIFF
--- a/src/spanner-assert.ts
+++ b/src/spanner-assert.ts
@@ -20,11 +20,11 @@ export function createSpannerAssert(
   const dbHandle = openDatabase(config);
 
   const assert = async (expectations: ExpectationsFile): Promise<void> => {
-    try {
-      await assertExpectations(dbHandle.database, expectations);
-    } finally {
-      await dbHandle.close();
-    }
+    await assertExpectations(dbHandle.database, expectations);
+  };
+
+  const close = async (): Promise<void> => {
+    await dbHandle.close();
   };
 
   const getConnectionInfo = (): SpannerConnectionConfig => ({
@@ -33,6 +33,7 @@ export function createSpannerAssert(
 
   return {
     assert,
+    close,
     getConnectionInfo,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,5 +24,6 @@ export type SpannerAssertOptions = {
 
 export type SpannerAssertInstance = {
   assert(expectations: ExpectationsFile): Promise<void>;
+  close(): Promise<void>;
   getConnectionInfo(): SpannerConnectionConfig;
 };

--- a/tests/e2e/run.ts
+++ b/tests/e2e/run.ts
@@ -43,6 +43,7 @@ async function main(): Promise<void> {
     throw error;
   } finally {
     console.log("Closing client resources...");
+    await spannerAssert.close();
     await database.close();
     spanner.close();
   }

--- a/tests/playwright/assert.spec.ts
+++ b/tests/playwright/assert.spec.ts
@@ -21,6 +21,10 @@ test.describe("spanner-assert with Playwright", () => {
     await seed();
   });
 
+  test.afterAll(async () => {
+    await spannerAssert.close();
+  });
+
   test("seeds are present in the emulator", async () => {
     await spannerAssert.assert(expectations);
   });


### PR DESCRIPTION
## Summary

- Added explicit `close()` method to `SpannerAssertInstance`
- Removed automatic connection close from `assert()` method
- Updated tests to explicitly call `close()` in cleanup hooks
- Enables connection reuse across multiple assertions

## Benefits

- **Reusable instances**: Can call `assert()` multiple times on same instance
- **Better performance**: Leverages Spanner's internal session pooling
- **Explicit resource control**: Developers control when to close connections
- **Backward compatible**: Adds `close()` method without breaking existing API

## Test Plan

- [x] Type checking passed
- [x] E2E tests with emulator passed
- [x] Playwright tests passed
- [x] Build successful